### PR TITLE
Removed NonZeroUsize (replaced with usize)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,11 +7,11 @@ documentation = "https://docs.rs/lbfgs"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 name = "lbfgs"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2018"
 
 [dependencies]
-num = "0.2.0"
+num-traits = "0.2.8"
 
 [dev-dependencies]
 unit_test_utils = "0.1.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,8 +18,8 @@
 //!
 //! fn main() {
 //!     // Problem size and the number of stored vectors in L-BFGS cannot be zero
-//!     let problem_size = NonZeroUsize::new(3).unwrap();
-//!     let lbfgs_memory_size = NonZeroUsize::new(5).unwrap();
+//!     let problem_size = 3;
+//!     let lbfgs_memory_size = 5;
 //!
 //!     // Create the L-BFGS instance with curvature and C-BFGS checks enabled
 //!     let mut lbfgs = Lbfgs::new(problem_size, lbfgs_memory_size)
@@ -79,9 +79,6 @@
 //! as the `problem_size`.
 //!
 
-extern crate num;
-pub use std::num::NonZeroUsize;
-
 pub mod vec_ops;
 
 #[cfg(test)]
@@ -139,9 +136,11 @@ pub enum UpdateStatus {
 
 impl Lbfgs {
     /// Create a new L-BFGS instance with a specific problem and L-BFGS buffer size
-    pub fn new(problem_size: NonZeroUsize, buffer_size: NonZeroUsize) -> Lbfgs {
-        let problem_size = problem_size.get();
-        let buffer_size = buffer_size.get();
+    pub fn new(problem_size: usize, buffer_size: usize) -> Lbfgs {
+        let problem_size = problem_size;
+        let buffer_size = buffer_size;
+        assert!(problem_size > 0);
+        assert!(buffer_size > 0);
 
         Lbfgs {
             active_size: 0,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -2,35 +2,45 @@ use crate::*;
 
 #[test]
 #[should_panic]
+fn lbfgs_panic_zero_n() {
+    let mut _e = Lbfgs::new(0, 1);
+}
+
+#[test]
+#[should_panic]
+fn lbfgs_panic_zero_mem() {
+    let mut _e = Lbfgs::new(1, 0);
+}
+
+#[test]
+#[should_panic]
 fn lbfgs_panic_apply_size_grad() {
-    let mut e = Lbfgs::new(NonZeroUsize::new(5).unwrap(), NonZeroUsize::new(5).unwrap());
+    let mut e = Lbfgs::new(5, 5);
     e.update_hessian(&[0.0; 4], &[0.0; 5]);
 }
 
 #[test]
 #[should_panic]
 fn lbfgs_panic_apply_state() {
-    let mut e = Lbfgs::new(NonZeroUsize::new(5).unwrap(), NonZeroUsize::new(5).unwrap());
+    let mut e = Lbfgs::new(5, 5);
     e.update_hessian(&[0.0; 5], &[0.0; 4]);
 }
 
 #[test]
 #[should_panic]
 fn lbfgs_panic_cbfgs_alpha() {
-    let mut _e = Lbfgs::new(NonZeroUsize::new(5).unwrap(), NonZeroUsize::new(5).unwrap())
-        .with_cbfgs_alpha(-1.0);
+    let mut _e = Lbfgs::new(5, 5).with_cbfgs_alpha(-1.0);
 }
 
 #[test]
 #[should_panic]
 fn lbfgs_panic_cbfgs_epsilon() {
-    let mut _e = Lbfgs::new(NonZeroUsize::new(5).unwrap(), NonZeroUsize::new(5).unwrap())
-        .with_cbfgs_epsilon(-1.0);
+    let mut _e = Lbfgs::new(5, 5).with_cbfgs_epsilon(-1.0);
 }
 
 #[test]
 fn lbfgs_buffer_storage() {
-    let mut e = Lbfgs::new(NonZeroUsize::new(2).unwrap(), NonZeroUsize::new(3).unwrap());
+    let mut e = Lbfgs::new(2, 3);
     e.update_hessian(&[1.0, 1.0], &[1.5, 1.5]);
     assert_eq!(e.active_size, 0);
 
@@ -83,7 +93,7 @@ fn lbfgs_buffer_storage() {
 
 #[test]
 fn lbfgs_apply_finite() {
-    let mut e = Lbfgs::new(NonZeroUsize::new(2).unwrap(), NonZeroUsize::new(3).unwrap());
+    let mut e = Lbfgs::new(2, 3);
     e.update_hessian(&[1.0, 1.0], &[1.5, 1.5]);
 
     let mut g = [1.0, 1.0];
@@ -94,7 +104,7 @@ fn lbfgs_apply_finite() {
 
 #[test]
 fn correctneess_buff_empty() {
-    let mut e = Lbfgs::new(NonZeroUsize::new(3).unwrap(), NonZeroUsize::new(3).unwrap());
+    let mut e = Lbfgs::new(3, 3);
     let mut g = [-3.1, 1.5, 2.1];
     assert_eq!(
         UpdateStatus::UpdateOk,
@@ -107,7 +117,7 @@ fn correctneess_buff_empty() {
 
 #[test]
 fn correctneess_buff_1() {
-    let mut e = Lbfgs::new(NonZeroUsize::new(3).unwrap(), NonZeroUsize::new(3).unwrap());
+    let mut e = Lbfgs::new(3, 3);
     let mut g = [-3.1, 1.5, 2.1];
 
     assert_eq!(
@@ -131,7 +141,7 @@ fn correctneess_buff_1() {
 
 #[test]
 fn correctneess_buff_2() {
-    let mut e = Lbfgs::new(NonZeroUsize::new(3).unwrap(), NonZeroUsize::new(3).unwrap());
+    let mut e = Lbfgs::new(3, 3);
     let mut g = [-3.1, 1.5, 2.1];
 
     assert_eq!(
@@ -156,7 +166,7 @@ fn correctneess_buff_2() {
 
 #[test]
 fn correctneess_buff_overfull() {
-    let mut e = Lbfgs::new(NonZeroUsize::new(3).unwrap(), NonZeroUsize::new(3).unwrap());
+    let mut e = Lbfgs::new(3, 3);
     let mut g = [-2.0, 0.2, -0.3];
 
     assert_eq!(
@@ -216,7 +226,7 @@ fn correctneess_buff_overfull() {
 
 #[test]
 fn correctneess_reset() {
-    let mut e = Lbfgs::new(NonZeroUsize::new(3).unwrap(), NonZeroUsize::new(3).unwrap());
+    let mut e = Lbfgs::new(3, 3);
     let mut g = [-3.1, 1.5, 2.1];
 
     assert_eq!(
@@ -258,8 +268,8 @@ fn correctneess_reset() {
 
 #[test]
 fn reject_perpendicular_sy() {
-    let n = NonZeroUsize::new(3).unwrap();
-    let mem = NonZeroUsize::new(5).unwrap();
+    let n = 3;
+    let mem = 5;
     let mut lbfgs = Lbfgs::new(n, mem).with_sy_epsilon(1e-8);
 
     assert_eq!(
@@ -300,8 +310,8 @@ fn reject_perpendicular_sy() {
 
 #[test]
 fn reject_norm_s_zero() {
-    let n = NonZeroUsize::new(3).unwrap();
-    let mem = NonZeroUsize::new(5).unwrap();
+    let n = 3;
+    let mem = 5;
     let mut lbfgs = Lbfgs::new(n, mem);
 
     assert_eq!(
@@ -324,8 +334,8 @@ fn reject_norm_s_zero() {
 
 #[test]
 fn reject_cfbs_condition() {
-    let n = NonZeroUsize::new(3).unwrap();
-    let mem = NonZeroUsize::new(5).unwrap();
+    let n = 3;
+    let mem = 5;
     let mut lbfgs = Lbfgs::new(n, mem)
         .with_sy_epsilon(1e-8)
         .with_cbfgs_alpha(1.0)

--- a/src/vec_ops.rs
+++ b/src/vec_ops.rs
@@ -3,7 +3,7 @@
 //! Matrix operations used by the L-BFGS algorithm.
 //!
 
-use num::{Float, Zero};
+use num_traits::{float::Float, identities::Zero};
 use std::iter::Sum;
 use std::ops::Mul;
 


### PR DESCRIPTION
List of changes:

- Changed dependency `num` to `num-traits` which is lighter 
- testing whether `n` and `mem` are zero (using `assert!`) when constructing instances of `Lbfgs`
- bumped version to `0.2.0`
- additional unit tests for `n=0` and `mem=0`

:memo: After that, @korken89, you could update the crate on crates.io so that we can simplify OpEn.